### PR TITLE
Disable parallelism in test suite

### DIFF
--- a/env-extra.cabal
+++ b/env-extra.cabal
@@ -45,7 +45,6 @@ test-suite env-extra-test
       Paths_env_extra
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , env-extra

--- a/package.yaml
+++ b/package.yaml
@@ -26,10 +26,6 @@ tests:
   env-extra-test:
     main:                Spec.hs
     source-dirs:         test
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
     dependencies:
     - env-extra
     - tasty

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,7 +24,8 @@ import           Test.Tasty.HUnit
 main :: IO ()
 main
   = defaultMain
-  $ testGroup "env extra"
+  -- don't execute setEnv in parallel
+  $ sequentialTestGroup "env extra" AllFinish
   [ testCase "return Nothing when variable is not set" $
     envMaybe "DEFINITELY_NOT_SET" >>= (@?= Nothing)
 


### PR DESCRIPTION
setenv(3) is [not thread safe] and neither is setEnv. While the test suite doesn't manage to segfault in my testing it will randomly fail in the decimal parsing test.

[not thread safe]: https://www.evanjones.ca/setenv-is-not-thread-safe.html